### PR TITLE
Change docker base image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.10-alpine
+FROM python:3.10-buster
 ENV PYTHONUNBUFFERED=1
 RUN pip install --upgrade pip
-# required for psycopg2
-RUN apk update && apk add g++ postgresql-dev gcc python3-dev musl-dev libffi-dev jpeg-dev zlib-dev
+# required for psycopg2 if using alpine base image
+# RUN apk update && apk add g++ postgresql-dev gcc python3-dev musl-dev libffi-dev jpeg-dev zlib-dev
 WORKDIR /app
 COPY requirements.txt /app
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Building from scratch on with alpine sometimes results in issues when trying to install packages such as pandas, numpy, scipy.
Switching to debian buster fixes these issues, also allows a removal a step that was required for psycopg2 install as well.
This does result in larger docker image but not using a docker repo so this isn't a concern right now.