### PR TITLE
fix bootstrap script: create database

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -58,8 +58,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   pyenv local 3.9.6
 
   echo "Setting up database"
-  createdb wsbots
-  sudo -u postgres psql postgres -d wsbots_db -f ./db_setup.sql
+  sudo -u postgres psql postgres -f ./db_setup.sql
 
 
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then


### PR DESCRIPTION
Environment: Ubuntu on Windows Subsystem for Linux

the command `createdb` was rejected because it wasn't run under the
postgresql user. and it isn't necessary because the db_setup.sql script
creates it